### PR TITLE
changed times to UTC as per dhcpd.leases man page

### DIFF
--- a/isc_dhcp_leases/iscdhcpleases.py
+++ b/isc_dhcp_leases/iscdhcpleases.py
@@ -113,9 +113,9 @@ class Lease(object):
         :return: bool: True if lease is valid
         """
         if self.end is None:
-            return self.start <= datetime.datetime.now()
+            return self.start <= datetime.datetime.utcnow()
         else:
-            return self.start <= datetime.datetime.now() <= self.end
+            return self.start <= datetime.datetime.utcnow() <= self.end
 
     @property
     def active(self):
@@ -175,7 +175,7 @@ class Lease6(object):
         if self.end is None:
             return True
         else:
-            return datetime.datetime.now() <= self.end
+            return datetime.datetime.utcnow() <= self.end
 
     @property
     def active(self):


### PR DESCRIPTION
as per dhcp.leases man page all times are specified in UTC. Thus the valid check was broken on machines where local time is not UTC.