### PR TITLE
Handle Lease functionalities when 'starts' is missing

### DIFF
--- a/isc_dhcp_leases/iscdhcpleases.py
+++ b/isc_dhcp_leases/iscdhcpleases.py
@@ -208,8 +208,10 @@ class Lease(BaseLease):
 
     def __init__(self, ip, properties, options=None, sets=None):
         super(Lease, self).__init__(ip, properties=properties, options=options, sets=sets)
-
-        self.start = parse_time(properties['starts'])
+        if 'starts' in properties:
+            self.start = parse_time(properties['starts'])
+        else:
+            self.start = None
         if properties.get('ends', 'never') == 'never':
             self.end = None
         else:
@@ -231,9 +233,15 @@ class Lease(BaseLease):
         :return: bool: True if lease is valid
         """
         if self.end is None:
-            return self.start <= datetime.datetime.utcnow()
+            if self.start is not None:
+                return self.start <= datetime.datetime.utcnow()
+            else:
+                return True
         else:
-            return self.start <= datetime.datetime.utcnow() <= self.end
+            if self.start is not None:
+                return self.start <= datetime.datetime.utcnow() <= self.end
+            else:
+                return datetime.datetime.utcnow() <= self.end
 
     def __repr__(self):
         return "<Lease {} for {} ({})>".format(self.ip, self.ethernet, self.hostname)

--- a/isc_dhcp_leases/test_lease.py
+++ b/isc_dhcp_leases/test_lease.py
@@ -63,3 +63,28 @@ class TestLease(TestCase):
         lease_b.ip = "192.168.0.1"
         lease_b.ethernet = "60:a4:4c:b5:6a:de"
         self.assertNotEqual(lease_a, lease_b)
+
+    def test_init_no_starts_property(self):
+        self.lease_data.pop('starts')
+        lease = Lease("192.168.0.1", self.lease_data)
+        self.assertEqual(lease.ip, "192.168.0.1")
+        self.assertEqual(lease.hardware, "ethernet")
+        self.assertEqual(lease.ethernet, "60:a4:4c:b5:6a:dd")
+        self.assertEqual(lease.hostname, "Satellite-C700")
+        self.assertIsNone(lease.end)
+        self.assertIsNone(lease.start)
+        self.assertTrue(lease.valid)
+        self.assertFalse(lease.active)
+        self.assertEqual(lease.binding_state, 'free')
+
+    @freeze_time("2015-07-6 8:15:0")
+    def test_valid_no_starts_property(self):
+        self.lease_data.pop('starts')
+        lease = Lease("192.168.0.1", self.lease_data)
+        self.assertTrue(lease.valid)  # Lease is forever
+
+        lease.end = datetime(2015, 7, 6, 6, 57, 4)
+        self.assertFalse(lease.valid)  # Lease is ended
+
+        lease.end = datetime(2015, 7, 6, 9, 57, 4)
+        self.assertTrue(lease.valid)  # Lease is not expired


### PR DESCRIPTION
The existing code base expected each lease entry will have 'starts'
property and the code fails at:
https://github.com/MartijnBraam/python-isc-dhcp-leases/blob/master/isc_dhcp_leases/iscdhcpleases.py#L212
self.start = parse_time(properties['starts'])

But lease entry could be without 'starts', like in below 3 examples:
lease 10.37.178.69 {
  tstp 5 2018/03/30 18:24:01;
  tsfp 5 2018/03/30 18:24:01;
  atsfp 5 2018/03/30 18:24:01;
  cltt 5 2018/03/30 17:54:01;
  binding state free;
  hardware ethernet 8c:dc:d4:b2:ea:fc;
  set vendorclass = "PXEClient:Arch:00000:UNDI:002001";
  set ClientIP = "10.37.178.69";
  set ClientMac = "8c:dc:d4:b2:ea:fc";
  set Vendorid = "PXEClient";
}
lease 10.37.178.68 {
  tstp 4 2018/03/29 22:08:05;
  tsfp 4 2018/03/29 22:08:05;
  atsfp 4 2018/03/29 22:08:05;
  cltt 4 2018/03/29 21:38:05;
  binding state free;
  hardware ethernet 8c:dc:d4:b2:d0:a8;
  set vendorclass = "d-i";
}
lease 10.37.178.67 {
  tstp 4 2018/03/29 20:22:16;
  tsfp 4 2018/03/29 20:22:16;
  atsfp 4 2018/03/29 20:22:16;
  binding state free;
  hardware ethernet 8c:dc:d4:b2:d0:a8;
}

This patch fixes the assumption.