### PR TITLE
Handle epoch timestamps in dhcpd.leases

### DIFF
--- a/isc_dhcp_leases/iscdhcpleases.py
+++ b/isc_dhcp_leases/iscdhcpleases.py
@@ -12,10 +12,18 @@ def parse_time(s):
     """
     Like datetime.datetime.strptime(s, "%w %Y/%m/%d %H:%M:%S") but 5x faster.
     """
-    _, date_part, time_part = s.split(' ')
-    year, mon, day = date_part.split('/')
-    hour, minute, sec = time_part.split(':')
-    return datetime.datetime(*map(int, (year, mon, day, hour, minute, sec)))
+    result = None
+
+    if "epoch" in s:
+        epoch_time = float(s.rstrip().split(' ')[1][:-1])
+        result = datetime.datetime.utcfromtimestamp(epoch_time)
+    else:
+        _, date_part, time_part = s.split(' ')
+        year, mon, day = date_part.split('/')
+        hour, minute, sec = time_part.split(':')
+        result = datetime.datetime(*map(int, (year, mon, day, hour, minute, sec)))
+
+    return result
 
 
 def _extract_prop_option(line):
@@ -67,7 +75,7 @@ def _extract_properties(config):
     for line in config.splitlines():
 
         # skip empty & malformed lines
-        if not line or not line[-1:] == ';':
+        if not line or not line[-1:] == ';' and '; #' not in line:
             continue
 
         # strip the trailing ';' and remove any whitespaces on the left side

--- a/isc_dhcp_leases/test_files/epoch.leases
+++ b/isc_dhcp_leases/test_files/epoch.leases
@@ -1,0 +1,18 @@
+lease 10.0.0.1 {
+  starts epoch 1507216949; # Thu Oct 05 15:22:29 2017
+  ends epoch 1508141363; # Mon Oct 16 08:09:23 2017
+  tstp epoch 1508141363; # Mon Oct 16 08:09:23 2017
+  tsfp epoch 1508141363; # Mon Oct 16 08:09:23 2017
+  atsfp epoch 1508141363; # Mon Oct 16 08:09:23 2017
+  cltt epoch 1508167349; # Thu Oct 05 15:22:29 2017
+  binding state backup;
+  hardware ethernet 2a:b2:2a:b2:2a:b2;
+  uid "\001\000!\314\006\224\351";
+}
+lease 10.0.0.2 {
+  starts epoch 1507637114; # Tue Oct 1012:05:14 2017
+  tstp epoch 1507637114; # Tue Oct 1012:05:14 2017
+  tsfp epoch 1507637114; # Tue Oct 1012:05:14 2017
+  atsfp epoch 1507637114; # Tue Oct 1012:05:14 2017
+  binding state backup;
+}

--- a/isc_dhcp_leases/test_iscDhcpLeases.py
+++ b/isc_dhcp_leases/test_iscDhcpLeases.py
@@ -146,6 +146,28 @@ class TestIscDhcpLeases(TestCase):
         self.assertEqual(result[1].start, datetime(2017, 10, 10, 12, 5, 14))
         self.assertIsNone(result[1].end)
 
+    @freeze_time("2015-06-6 8:15:0")
+    def test_epoch_leases(self):
+        leases = IscDhcpLeases("isc_dhcp_leases/test_files/epoch.leases")
+        result = leases.get()
+        self.assertEqual(len(result), 1)
+        result = leases.get(include_backups=True)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0].ip, "10.0.0.1")
+        self.assertEqual(result[0].valid, False)
+        self.assertEqual(result[0].active, False)
+        self.assertEqual(result[0].binding_state, "backup")
+        self.assertEqual(result[0].hardware, "ethernet")
+        self.assertEqual(result[0].start, datetime(2017, 10, 5, 15, 22, 29))
+        self.assertEqual(result[0].end, datetime(2017, 10, 16, 8, 9, 23))
+        self.assertEqual(result[1].ip, "10.0.0.2")
+        self.assertEqual(result[1].valid, False)
+        self.assertEqual(result[1].active, False)
+        self.assertEqual(result[1].binding_state, "backup")
+        self.assertIsNone(result[1].hardware)
+        self.assertEqual(result[1].start, datetime(2017, 10, 10, 12, 5, 14))
+        self.assertIsNone(result[1].end)
+
     @freeze_time("2015-07-6 8:15:0")
     def test_get_current(self):
         leases = IscDhcpLeases("isc_dhcp_leases/test_files/debian7.leases")


### PR DESCRIPTION
https://www.isc.org/wp-content/uploads/2017/08/dhcp43leases.html

If the db-time-format was configured to local, then the date fields
appear as follows:

epoch <seconds-since-epoch>; # <day-name> <month-name> <day-number>
<hours>:<minutes>:<seconds> <year>