### PR TITLE
Add test_files content to packaging

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -6,3 +6,12 @@ isc_dhcp_leases/iscdhcpleases.py
 isc_dhcp_leases/test_iscDhcpLeases.py
 isc_dhcp_leases/test_lease.py
 isc_dhcp_leases/test_lease6.py
+isc_dhcp_leases/test_files/backup.leases
+isc_dhcp_leases/test_files/debian7.leases
+isc_dhcp_leases/test_files/debian7.leases.gz
+isc_dhcp_leases/test_files/dhcpd6-4.2.4.leases
+isc_dhcp_leases/test_files/dhcpd6-4.3.3.leases
+isc_dhcp_leases/test_files/epoch.leases
+isc_dhcp_leases/test_files/options.leases
+isc_dhcp_leases/test_files/pfsense.leases
+isc_dhcp_leases/test_files/static.leases

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
     name='isc_dhcp_leases',
     version='0.9.1',
     packages=['isc_dhcp_leases'],
+    package_data={'isc_dhcp_leases': ['test_files/*']},
     url='https://github.com/MartijnBraam/python-isc-dhcp-leases',
     install_requires=['six'],
     license='MIT',
@@ -60,6 +61,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5'
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6'
     ]
 )


### PR DESCRIPTION
Provide test_files content in the distribution so downstream packagers sourcing from PyPI can run all tests successfully. While here, also note Python 3.6 support, since that's what I'm using it with.