### PR TITLE
relax parsing rules to accept openbsd's dhcpd.leases format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: test
+
+test:
+	python setup.py test

--- a/isc_dhcp_leases/test_files/openbsd-6.4.leases
+++ b/isc_dhcp_leases/test_files/openbsd-6.4.leases
@@ -1,0 +1,45 @@
+lease 192.168.64.40 {
+	starts 2 2019/04/23 17:45:46 UTC;
+	ends 3 2019/04/24 05:45:46 UTC;
+	hardware ethernet 00:15:5d:84:97:62;
+	uid 01:00:15:5d:84:97:62;
+	client-hostname "puffy";
+}
+lease 192.168.64.37 {
+	starts 2 2019/04/23 17:08:29 UTC;
+	ends 3 2019/04/24 05:08:29 UTC;
+	hardware ethernet 40:4e:36:8a:f5:51;
+	uid 01:40:4e:36:8a:f5:51;
+}
+lease 192.168.64.32 {
+	starts 2 2019/04/23 16:50:36 UTC;
+	ends 3 2019/04/24 04:50:36 UTC;
+	hardware ethernet 00:15:5d:84:97:29;
+	client-hostname "devo";
+}
+lease 192.168.64.48 {
+	starts 2 2019/04/23 16:14:00 UTC;
+	ends 3 2019/04/24 04:14:00 UTC;
+	hardware ethernet 00:15:5d:84:97:6b;
+	uid 01:00:15:5d:84:97:6b;
+	client-hostname "testbed";
+}
+lease 192.168.64.52 {
+	starts 2 2019/03/12 19:49:31 UTC;
+	ends 3 2019/03/13 07:49:31 UTC;
+	hardware ethernet 00:a0:cc:63:b6:72;
+}
+lease 192.168.64.53 {
+	starts 2 2019/03/12 17:51:45 UTC;
+	ends 3 2019/03/13 05:51:45 UTC;
+	hardware ethernet 00:a0:cc:63:b6:72;
+	client-hostname "mailhub.rstms.net";
+}
+lease 192.168.64.51 {
+	starts 2 2019/03/12 17:45:21 UTC;
+	ends 2 2019/03/12 17:49:32 UTC;
+	hardware ethernet 00:a0:cc:63:b6:72;
+	abandoned;
+	client-hostname "mailhub.rstms.net";
+}
+

--- a/isc_dhcp_leases/test_iscDhcpLeases.py
+++ b/isc_dhcp_leases/test_iscDhcpLeases.py
@@ -5,7 +5,6 @@ from datetime import datetime
 
 __author__ = 'Martijn Braam <martijn@brixit.nl>'
 
-
 class TestIscDhcpLeases(TestCase):
     @freeze_time("2015-07-6 8:15:0")
     def test_get(self):
@@ -123,6 +122,20 @@ class TestIscDhcpLeases(TestCase):
         self.assertEqual(result[0].hardware, "ethernet")
         self.assertEqual(result[0].start, datetime(2015, 9, 10, 0, 29, 0))
         self.assertIsNone(result[0].end)
+
+    @freeze_time("2019-04-24 1:1:1")
+    def test_get(self):
+        leases = IscDhcpLeases("isc_dhcp_leases/test_files/openbsd-6.4.leases")
+        result = leases.get()
+        r=result[0]
+        self.assertEqual(len(result), 7)
+        self.assertEqual(result[0].ip, "192.168.64.40")
+        self.assertEqual(result[0].valid, True)
+        self.assertEqual(result[0].active, True)
+        self.assertEqual(result[0].binding_state, "active")
+        self.assertEqual(result[0].hardware, "ethernet")
+        self.assertEqual(result[0].start, datetime(2019, 4, 23, 17, 45, 46))
+        self.assertEqual(result[0].end, datetime(2019, 4, 24, 5, 45, 46))
 
     @freeze_time("2015-06-6 8:15:0")
     def test_backup_leases(self):


### PR DESCRIPTION
I made these changes because I needed this to run on my OpenBSD 6.4 system, which uses a dhcpd that is derived from isc-dhcpd.   The dhcpd.leases file has minor differences which required changes to the parser.  The existing tests all still pass.

These changes allow the module to read the OpenBSD lease file:

ignore 'UTC' suffix on time fields
record with missing binding_state defaults to 'active'
interpret 'abandoned;' field as 'binding_state abandoned;"
added test case for openbsd dhcpd.leases
added Makefile for `make test`