### PR TITLE
Support reference datetime for examining historical dhcpd.leases

### DIFF
--- a/isc_dhcp_leases/iscdhcpleases.py
+++ b/isc_dhcp_leases/iscdhcpleases.py
@@ -214,8 +214,8 @@ class Lease(BaseLease):
         data            Dict of all the info in the dhcpd.leases file for this lease
     """
 
-    def __init__(self, ip, properties, options=None, sets=None):
-        super(Lease, self).__init__(ip, properties=properties, options=options, sets=sets)
+    def __init__(self, ip, properties, **kwargs):
+        super(Lease, self).__init__(ip, properties=properties, **kwargs)
         if 'starts' in properties:
             self.start = parse_time(properties['starts'])
         else:
@@ -278,11 +278,8 @@ class Lease6(BaseLease):
 
     (TEMPORARY, NON_TEMPORARY, PREFIX_DELEGATION) = ('ta', 'na', 'pd')
 
-    def __init__(self, ip, properties, cltt, host_identifier, address_type, options=None, sets=None):
-        options = options or {}
-        sets = sets or {}
-
-        super(Lease6, self).__init__(ip, properties=properties, options=options, sets=sets)
+    def __init__(self, ip, properties, cltt, host_identifier, address_type, **kwargs):
+        super(Lease6, self).__init__(ip, properties=properties, **kwargs)
 
         self.type = address_type
         self.last_communication = cltt

--- a/isc_dhcp_leases/iscdhcpleases.py
+++ b/isc_dhcp_leases/iscdhcpleases.py
@@ -23,7 +23,7 @@ def parse_time(s):
         hour, minute, sec = time_part.split(':')
         result = datetime.datetime(*map(int, (year, mon, day, hour, minute, sec)))
 
-    return result
+    return result.replace(tzinfo=datetime.timezone.utc)
 
 
 def _extract_prop_option(line):
@@ -198,6 +198,9 @@ class BaseLease(object):
         """
         return self.binding_state == 'active'
 
+    @property
+    def now(self):
+        return datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc)
 
 class Lease(BaseLease):
     """
@@ -242,14 +245,14 @@ class Lease(BaseLease):
         """
         if self.end is None:
             if self.start is not None:
-                return self.start <= datetime.datetime.utcnow()
+                return self.start <= self.now
             else:
                 return True
         else:
             if self.start is not None:
-                return self.start <= datetime.datetime.utcnow() <= self.end
+                return self.start <= self.now <= self.end
             else:
-                return datetime.datetime.utcnow() <= self.end
+                return self.now <= self.end
 
     def __repr__(self):
         return "<Lease {} for {} ({})>".format(self.ip, self.ethernet, self.hostname)
@@ -312,7 +315,7 @@ class Lease6(BaseLease):
         if self.end is None:
             return True
         else:
-            return datetime.datetime.utcnow() <= self.end
+            return self.now <= self.end
 
     def __repr__(self):
         return "<Lease6 {}>".format(self.ip)

--- a/isc_dhcp_leases/test_iscDhcpLeases.py
+++ b/isc_dhcp_leases/test_iscDhcpLeases.py
@@ -1,7 +1,7 @@
+import datetime
 from unittest import TestCase
 from isc_dhcp_leases.iscdhcpleases import IscDhcpLeases, Lease, Lease6
 from freezegun import freeze_time
-from datetime import datetime
 
 __author__ = 'Martijn Braam <martijn@brixit.nl>'
 
@@ -10,6 +10,8 @@ class TestIscDhcpLeases(TestCase):
     @freeze_time("2015-07-6 8:15:0")
     def test_get(self):
         leases = IscDhcpLeases("isc_dhcp_leases/test_files/debian7.leases")
+        lease_start = datetime.datetime(2013, 12, 10, 12, 57, 4, tzinfo=datetime.timezone.utc)
+        lease_end = lease_start + datetime.timedelta(minutes=10)
         result = leases.get()
         self.assertEqual(len(result), 5)
         self.assertEqual(result[0].ip, "10.0.0.10")
@@ -19,11 +21,13 @@ class TestIscDhcpLeases(TestCase):
         self.assertEqual(result[0].hardware, "ethernet")
         self.assertEqual(result[0].ethernet, "60:a4:4c:b5:6a:dd")
         self.assertEqual(result[0].hostname, "")
-        self.assertEqual(result[0].start, datetime(2013, 12, 10, 12, 57, 4))
-        self.assertEqual(result[0].end, datetime(2013, 12, 10, 13, 7, 4))
+        self.assertEqual(result[0].start, lease_start)
+        self.assertEqual(result[0].end, lease_end)
         self.assertEqual(result[0].sets, {'vendor-class-identifier': 'Some Vendor Identifier'})
 
         leases = IscDhcpLeases("isc_dhcp_leases/test_files/pfsense.leases")
+        lease_start = datetime.datetime(2015, 7, 6, 7, 50, 42, tzinfo=datetime.timezone.utc)
+        lease_end = lease_start + datetime.timedelta(minutes=30)
         result = leases.get()
         self.assertEqual(len(result), 2)
         self.assertEqual(result[0].ip, "10.0.10.72")
@@ -33,8 +37,8 @@ class TestIscDhcpLeases(TestCase):
         self.assertEqual(result[0].hardware, "ethernet")
         self.assertEqual(result[0].ethernet, "64:5a:04:6a:07:a2")
         self.assertEqual(result[0].hostname, "Satellite-C700")
-        self.assertEqual(result[0].start, datetime(2015, 7, 6, 7, 50, 42))
-        self.assertEqual(result[0].end, datetime(2015, 7, 6, 8, 20, 42))
+        self.assertEqual(result[0].start, lease_start)
+        self.assertEqual(result[0].end, lease_end)
 
         leases = IscDhcpLeases("isc_dhcp_leases/test_files/dhcpd6-4.2.4.leases")
         result = leases.get()
@@ -48,7 +52,9 @@ class TestIscDhcpLeases(TestCase):
         self.assertEqual(result[0].binding_state, 'active')
         self.assertEqual(result[0].preferred_life, 375)
         self.assertEqual(result[0].max_life, 600)
-        self.assertEqual(result[0].last_communication, datetime(2015, 8, 18, 16, 55, 37))
+        self.assertEqual(
+            result[0].last_communication,
+            datetime.datetime(2015, 8, 18, 16, 55, 37, tzinfo=datetime.timezone.utc))
         self.assertEqual(result[0].type, Lease6.NON_TEMPORARY)
 
         self.assertEqual(result[1].ip, "2001:610:500:fff::/64")
@@ -60,7 +66,9 @@ class TestIscDhcpLeases(TestCase):
         self.assertEqual(result[1].binding_state, 'active')
         self.assertEqual(result[1].preferred_life, 175)
         self.assertEqual(result[1].max_life, 200)
-        self.assertEqual(result[1].last_communication, datetime(2015, 8, 18, 16, 55, 40))
+        self.assertEqual(
+            result[1].last_communication,
+            datetime.datetime(2015, 8, 18, 16, 55, 40, tzinfo=datetime.timezone.utc))
         self.assertEqual(result[1].type, Lease6.PREFIX_DELEGATION)
 
         leases = IscDhcpLeases("isc_dhcp_leases/test_files/dhcpd6-4.3.3.leases")
@@ -75,7 +83,9 @@ class TestIscDhcpLeases(TestCase):
         self.assertEqual(result[0].binding_state, 'active')
         self.assertEqual(result[0].preferred_life, 540)
         self.assertEqual(result[0].max_life, 864)
-        self.assertEqual(result[0].last_communication, datetime(2016, 1, 6, 14, 50, 34))
+        self.assertEqual(
+            result[0].last_communication,
+            datetime.datetime(2016, 1, 6, 14, 50, 34, tzinfo=datetime.timezone.utc))
         self.assertEqual(result[0].type, Lease6.NON_TEMPORARY)
         self.assertEqual(result[0].sets, dict(iana='2001:10:10:0:0:0:0:106', clientduid='0100011cf710a5002722332b34'))
 
@@ -88,13 +98,17 @@ class TestIscDhcpLeases(TestCase):
         self.assertEqual(result[1].binding_state, 'active')
         self.assertEqual(result[1].preferred_life, 540)
         self.assertEqual(result[1].max_life, 864)
-        self.assertEqual(result[1].last_communication, datetime(2016, 1, 6, 14, 52, 37))
+        self.assertEqual(
+            result[1].last_communication,
+            datetime.datetime(2016, 1, 6, 14, 52, 37, tzinfo=datetime.timezone.utc))
         self.assertEqual(result[1].type, Lease6.PREFIX_DELEGATION)
         self.assertEqual(result[1].sets, dict(iapd='2001:10:30:ff00:0:0:0:0', pdsize='56',
                                               pdnet='2001:10:30:ff00:0:0:0:0/56',
                                               clientduid='0100011d344c000025906ba134'))
 
         leases = IscDhcpLeases("isc_dhcp_leases/test_files/options.leases")
+        lease_start = datetime.datetime(2016, 2, 27, 7, 11, 41, tzinfo=datetime.timezone.utc)
+        lease_end = lease_start + datetime.timedelta(hours=2)
         result = leases.get()
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0].ip, "10.10.10.10")
@@ -104,8 +118,8 @@ class TestIscDhcpLeases(TestCase):
         self.assertEqual(result[0].hardware, "ethernet")
         self.assertEqual(result[0].ethernet, "24:65:11:d9:a6:b3")
         self.assertEqual(result[0].hostname, "KRONOS")
-        self.assertEqual(result[0].start, datetime(2016, 2, 27, 7, 11, 41))
-        self.assertEqual(result[0].end, datetime(2016, 2, 27, 9, 11, 41))
+        self.assertEqual(result[0].start, lease_start)
+        self.assertEqual(result[0].end, lease_end)
         self.assertEqual(len(result[0].options), 4)
         self.assertDictEqual(result[0].options,
                              {'agent.DOCSIS-device-class': '2',
@@ -114,6 +128,8 @@ class TestIscDhcpLeases(TestCase):
                               'agent.unknown-9': '0:0:11:8b:6:1:4:1:2:3:0'})
 
         leases = IscDhcpLeases("isc_dhcp_leases/test_files/static.leases")
+        lease_start = datetime.datetime(2015, 9, 10, 0, 29, 0, tzinfo=datetime.timezone.utc)
+        lease_end = None
         result = leases.get()
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0].ip, "10.0.0.15")
@@ -121,12 +137,20 @@ class TestIscDhcpLeases(TestCase):
         self.assertEqual(result[0].active, False)
         self.assertEqual(result[0].binding_state, "free")
         self.assertEqual(result[0].hardware, "ethernet")
-        self.assertEqual(result[0].start, datetime(2015, 9, 10, 0, 29, 0))
-        self.assertIsNone(result[0].end)
+        self.assertEqual(result[0].start, lease_start)
+        self.assertEqual(result[0].end, lease_end)
 
     @freeze_time("2015-06-6 8:15:0")
     def test_backup_leases(self):
         leases = IscDhcpLeases("isc_dhcp_leases/test_files/backup.leases")
+        lease_start = [
+            datetime.datetime(2017, 10, 5, 15, 22, 29, tzinfo=datetime.timezone.utc),
+            datetime.datetime(2017, 10, 10, 12, 5, 14, tzinfo=datetime.timezone.utc),
+        ]
+        lease_end = [
+            datetime.datetime(2017, 10, 16, 8, 9, 23, tzinfo=datetime.timezone.utc),
+            None,
+        ]
         result = leases.get()
         self.assertEqual(len(result), 1)
         result = leases.get(include_backups=True)
@@ -136,19 +160,27 @@ class TestIscDhcpLeases(TestCase):
         self.assertEqual(result[0].active, False)
         self.assertEqual(result[0].binding_state, "backup")
         self.assertEqual(result[0].hardware, "ethernet")
-        self.assertEqual(result[0].start, datetime(2017, 10, 5, 15, 22, 29))
-        self.assertEqual(result[0].end, datetime(2017, 10, 16, 8, 9, 23))
+        self.assertEqual(result[0].start, lease_start[0])
+        self.assertEqual(result[0].end, lease_end[0])
         self.assertEqual(result[1].ip, "10.0.0.2")
         self.assertEqual(result[1].valid, False)
         self.assertEqual(result[1].active, False)
         self.assertEqual(result[1].binding_state, "backup")
         self.assertIsNone(result[1].hardware)
-        self.assertEqual(result[1].start, datetime(2017, 10, 10, 12, 5, 14))
-        self.assertIsNone(result[1].end)
+        self.assertEqual(result[1].start, lease_start[1])
+        self.assertEqual(result[1].end, lease_end[1])
 
     @freeze_time("2015-06-6 8:15:0")
     def test_epoch_leases(self):
         leases = IscDhcpLeases("isc_dhcp_leases/test_files/epoch.leases")
+        lease_start = [
+            datetime.datetime(2017, 10, 5, 15, 22, 29, tzinfo=datetime.timezone.utc),
+            datetime.datetime(2017, 10, 10, 12, 5, 14, tzinfo=datetime.timezone.utc),
+        ]
+        lease_end = [
+            datetime.datetime(2017, 10, 16, 8, 9, 23, tzinfo=datetime.timezone.utc),
+            None,
+        ]
         result = leases.get()
         self.assertEqual(len(result), 1)
         result = leases.get(include_backups=True)
@@ -158,15 +190,15 @@ class TestIscDhcpLeases(TestCase):
         self.assertEqual(result[0].active, False)
         self.assertEqual(result[0].binding_state, "backup")
         self.assertEqual(result[0].hardware, "ethernet")
-        self.assertEqual(result[0].start, datetime(2017, 10, 5, 15, 22, 29))
-        self.assertEqual(result[0].end, datetime(2017, 10, 16, 8, 9, 23))
+        self.assertEqual(result[0].start, lease_start[0])
+        self.assertEqual(result[0].end, lease_end[0])
         self.assertEqual(result[1].ip, "10.0.0.2")
         self.assertEqual(result[1].valid, False)
         self.assertEqual(result[1].active, False)
         self.assertEqual(result[1].binding_state, "backup")
         self.assertIsNone(result[1].hardware)
-        self.assertEqual(result[1].start, datetime(2017, 10, 10, 12, 5, 14))
-        self.assertIsNone(result[1].end)
+        self.assertEqual(result[1].start, lease_start[1])
+        self.assertEqual(result[1].end, lease_end[1])
 
     @freeze_time("2015-07-6 8:15:0")
     def test_get_current(self):
@@ -201,6 +233,8 @@ class TestIscDhcpLeases(TestCase):
 
     def test_gzip_handling(self):
         leases = IscDhcpLeases("isc_dhcp_leases/test_files/debian7.leases.gz", True)
+        lease_start = datetime.datetime(2013, 12, 10, 12, 57, 4, tzinfo=datetime.timezone.utc)
+        lease_end = lease_start + datetime.timedelta(minutes=10)
         result = leases.get()
         self.assertEqual(len(result), 5)
         self.assertEqual(result[0].ip, "10.0.0.10")
@@ -210,6 +244,6 @@ class TestIscDhcpLeases(TestCase):
         self.assertEqual(result[0].hardware, "ethernet")
         self.assertEqual(result[0].ethernet, "60:a4:4c:b5:6a:dd")
         self.assertEqual(result[0].hostname, "")
-        self.assertEqual(result[0].start, datetime(2013, 12, 10, 12, 57, 4))
-        self.assertEqual(result[0].end, datetime(2013, 12, 10, 13, 7, 4))
+        self.assertEqual(result[0].start, lease_start)
+        self.assertEqual(result[0].end, lease_end)
         self.assertEqual(result[0].sets, {'vendor-class-identifier': 'Some Vendor Identifier'})

--- a/isc_dhcp_leases/test_lease.py
+++ b/isc_dhcp_leases/test_lease.py
@@ -1,7 +1,7 @@
+import datetime
 from unittest import TestCase
 from isc_dhcp_leases.iscdhcpleases import Lease
 from freezegun import freeze_time
-from datetime import datetime
 
 __author__ = 'Martijn Braam <martijn@brixit.nl>'
 
@@ -26,7 +26,8 @@ class TestLease(TestCase):
         self.assertEqual(lease.hardware, "ethernet")
         self.assertEqual(lease.ethernet, "60:a4:4c:b5:6a:dd")
         self.assertEqual(lease.hostname, "Satellite-C700")
-        self.assertEqual(lease.start, datetime(2013, 12, 10, 12, 57, 4))
+        self.assertEqual(
+            lease.start, datetime.datetime(2013, 12, 10, 12, 57, 4, tzinfo=datetime.timezone.utc))
         self.assertIsNone(lease.end)
         self.assertTrue(lease.valid)
         self.assertFalse(lease.active)
@@ -41,14 +42,14 @@ class TestLease(TestCase):
         lease = Lease("192.168.0.1", self.lease_data)
         self.assertTrue(lease.valid)  # Lease is forever
 
-        lease.end = datetime(2015, 7, 6, 13, 57, 4)
+        lease.end = datetime.datetime(2015, 7, 6, 13, 57, 4, tzinfo=datetime.timezone.utc)
         self.assertTrue(lease.valid)  # Lease is within start and end
 
-        lease.end = datetime(2015, 7, 6, 6, 57, 4)
+        lease.end = lease.end - datetime.timedelta(hours=7)
         self.assertFalse(lease.valid)  # Lease is ended
 
-        lease.start = datetime(2015, 7, 6, 12, 57, 4)
-        lease.end = datetime(2015, 7, 6, 13, 57, 4)
+        lease.start = datetime.datetime(2015, 7, 6, 12, 57, 4, tzinfo=datetime.timezone.utc)
+        lease.end = lease.start + datetime.timedelta(hours=1)
         self.assertFalse(lease.valid)  # Lease is in the future
 
     def test_eq(self):
@@ -83,8 +84,8 @@ class TestLease(TestCase):
         lease = Lease("192.168.0.1", self.lease_data)
         self.assertTrue(lease.valid)  # Lease is forever
 
-        lease.end = datetime(2015, 7, 6, 6, 57, 4)
+        lease.end = datetime.datetime(2015, 7, 6, 6, 57, 4, tzinfo=datetime.timezone.utc)
         self.assertFalse(lease.valid)  # Lease is ended
 
-        lease.end = datetime(2015, 7, 6, 9, 57, 4)
+        lease.end = lease.end + datetime.timedelta(hours=3)
         self.assertTrue(lease.valid)  # Lease is not expired

--- a/isc_dhcp_leases/test_lease6.py
+++ b/isc_dhcp_leases/test_lease6.py
@@ -1,13 +1,14 @@
+import datetime
 from unittest import TestCase
 from isc_dhcp_leases.iscdhcpleases import Lease6
 from freezegun import freeze_time
-from datetime import datetime
 
 __author__ = 'Martijn Braam <martijn@brixit.nl>'
 
 
 class TestLease6(TestCase):
     def setUp(self):
+        self.lease_time = datetime.datetime(2015, 8, 18, 16, 55, 37, tzinfo=datetime.timezone.utc)
         self.lease_data = {
             'binding': 'state active',
             'ends': 'never',
@@ -17,7 +18,7 @@ class TestLease6(TestCase):
 
     @freeze_time("2015-07-6 8:15:0")
     def test_init(self):
-        lease = Lease6("2001:610:600:891d::60", self.lease_data, datetime(2015, 8, 18, 16, 55, 37),
+        lease = Lease6("2001:610:600:891d::60", self.lease_data, self.lease_time,
                        "4dv\\352\\000\\001\\000\\001\\035f\\037\\342\\012\\000'\\000\\000\\000", "na")
         self.assertEqual(lease.ip, "2001:610:600:891d::60")
 
@@ -29,30 +30,30 @@ class TestLease6(TestCase):
         self.assertEqual(lease.binding_state, 'active')
         self.assertEqual(lease.preferred_life, 375)
         self.assertEqual(lease.max_life, 600)
-        self.assertEqual(lease.last_communication, datetime(2015, 8, 18, 16, 55, 37))
+        self.assertEqual(lease.last_communication, self.lease_time)
         self.assertEqual(lease.type, Lease6.NON_TEMPORARY)
 
     def test_repr(self):
-        lease = Lease6("2001:610:600:891d::60", self.lease_data, datetime(2015, 8, 18, 16, 55, 37),
+        lease = Lease6("2001:610:600:891d::60", self.lease_data, self.lease_time,
                        "4dv\\352\\000\\001\\000\\001\\035f\\037\\342\\012\\000'\\000\\000\\000", "na")
         self.assertEqual(repr(lease), '<Lease6 2001:610:600:891d::60>')
 
     @freeze_time("2015-07-6 8:15:0")
     def test_valid(self):
-        lease = Lease6("2001:610:600:891d::60", self.lease_data, datetime(2015, 8, 18, 16, 55, 37),
+        lease = Lease6("2001:610:600:891d::60", self.lease_data, self.lease_time,
                        "4dv\\352\\000\\001\\000\\001\\035f\\037\\342\\012\\000'\\000\\000\\000", "na")
         self.assertTrue(lease.valid)  # Lease is forever
 
-        lease.end = datetime(2015, 7, 6, 13, 57, 4)
+        lease.end = datetime.datetime(2015, 7, 6, 13, 57, 4, tzinfo=datetime.timezone.utc)
         self.assertTrue(lease.valid)  # Lease is before end
 
-        lease.end = datetime(2015, 7, 6, 6, 57, 4)
+        lease.end = lease.end - datetime.timedelta(hours=7)
         self.assertFalse(lease.valid)  # Lease is ended
 
     def test_eq(self):
-        lease_a = Lease6("2001:610:600:891d::60", self.lease_data, datetime(2015, 8, 18, 16, 55, 37),
+        lease_a = Lease6("2001:610:600:891d::60", self.lease_data, self.lease_time,
                          "4dv\\352\\000\\001\\000\\001\\035f\\037\\342\\012\\000'\\000\\000\\000", "na")
-        lease_b = Lease6("2001:610:600:891d::60", self.lease_data, datetime(2015, 8, 18, 16, 55, 37),
+        lease_b = Lease6("2001:610:600:891d::60", self.lease_data, self.lease_time,
                          "4dv\\352\\000\\001\\000\\001\\035f\\037\\342\\012\\000'\\000\\000\\000", "na")
 
         self.assertEqual(lease_a, lease_b)


### PR DESCRIPTION
While debugging a DHCP issue, I found myself needing to review historical `dhcpd.leases` files. It took me a while to realize it, but as time passed the results from my review started to change :frowning_face: 

I found that this module was checking lease validity against the current system time and that testing used `@freeze_time` decorators.

In order to do my work, I modified the module to also support a user-specified reference `datetime` object when initializing classes. I think that it could be useful to others, too.