### PR TITLE
Fully backward compatible revision to allow for parseing from str data as well as files and gzipped files.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,6 +69,16 @@ Or read a gzip'ed file:
                           # The key of the dict is the device mac address and the
                           # Value is a Lease object
 
+Or lease data in a str:
+
+.. code:: python
+
+    from isc_dhcp_leases import Lease, IscDhcpLeases
+    with open("/path/to/dhcpd.lease", "r", encoding="utf8") as infile:
+        contents = infile.read()
+    leases = IscDhcpLease(contents, is_data=True)
+    ...
+ 
 The Lease object has the following fields (only for IPv4 leases):
 
 .. code:: python


### PR DESCRIPTION
I see others have asked for the ability to parse from data as well.  I offer revision this for your consideration.
I did not do anything about unit tests though.  

	README.rst
		Added an example

	isc_dhcp_leases/iscdhcplease.py
		Unindented processing in IscDhcpLease.get after
		lease_data was attained to both release the file sooner
		and facilitate parseing from a string.

		Added some comments to IscDhcpLeases to help with the
		parameters.

		Added a optional bool:is_data to IscDhcpLeases to
		indicate the given source was str data and not a file
		name.

ps:  I really wanted to change the name of IscDhcpLease.filename to .source to make it cleared but there's that miniscule chance that someone somewhere actually used a named parameter or something.